### PR TITLE
docs(changelog): add v0.4.3 security release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2025-12-15
+
+### Security
+- 🔒 **CRITICAL**: Fixed MCP vulnerability (ID 82197) - Information Disclosure via HTTP-based localhost MCP
+- Updated `mcp` dependency from 1.14.1 to 1.24.0 to resolve security vulnerability
+- Verified full compatibility with existing codebase - no breaking changes
+
+### Changed
+- Bumped project version to reflect security patch
+
 ## [0.3.3] - 2024-09-26
 
 ### Fixed


### PR DESCRIPTION
## Description
Updates CHANGELOG.md to document the critical security release v0.4.3 that fixes MCP vulnerability ID 82197.

## Changes Made
- Added v0.4.3 release entry to CHANGELOG.md
- Documented MCP security vulnerability fix (ID 82197)
- Noted dependency update from mcp 1.14.1 to 1.24.0
- Confirmed no breaking changes in compatibility

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related Issues
Follows up on the security fix release that was just published to PyPI.